### PR TITLE
use JRuby 9.2's load-extension

### DIFF
--- a/lib/readline.rb
+++ b/lib/readline.rb
@@ -5,8 +5,12 @@ require "jline/jline/#{Readline::Version::JLINE_VERSION}/jline-#{Readline::Versi
 require "readline.jar"
 
 # boot extension
-begin
-  org.jruby.ext.readline.ReadlineService.new.load(JRuby.runtime, false)
-rescue NameError => ne
-  raise NameError, "unable to load readline subsystem: #{ne.message}", ne.backtrace
+if JRuby::Util.respond_to?(:load_ext)
+  JRuby::Util.load_ext('org.jruby.ext.readline.ReadlineService')
+else; require 'jruby'
+  begin
+    org.jruby.ext.readline.ReadlineService.new.load(JRuby.runtime, false)
+  rescue NameError => ne
+    raise NameError, "unable to load readline subsystem: #{ne.message}", ne.backtrace
+  end
 end


### PR DESCRIPTION
`JRuby::Util` is internal -> gets into `JRuby.load_ext` by the time `require 'jruby'` happens