### PR TITLE
 [fix] restoring terminal settings, for good!

### DIFF
--- a/lib/readline/version.rb
+++ b/lib/readline/version.rb
@@ -1,6 +1,6 @@
 module Readline
   module Version
-    VERSION = "1.3.6"
+    VERSION = "1.3.7"
     JLINE_VERSION = "2.14.6"
   end
 end

--- a/src/main/java/org/jruby/ext/readline/Readline.java
+++ b/src/main/java/org/jruby/ext/readline/Readline.java
@@ -127,6 +127,7 @@ public class Readline {
         readline.setHistoryEnabled(false);
         readline.setPaginationEnabled(true);
         readline.setBellEnabled(true);
+        readline.setHandleLitteralNext(false);
 
         if (holder.currentCompletor == null) {
             holder.currentCompletor = new RubyFileNameCompletor();

--- a/src/main/java/org/jruby/ext/readline/Readline.java
+++ b/src/main/java/org/jruby/ext/readline/Readline.java
@@ -119,7 +119,7 @@ public class Readline {
         final ConsoleReader readline;
         try {
             final Terminal terminal = TerminalFactory.create();
-            readline = holder.readline = new ConsoleReader(null, runtime.getInputStream(), runtime.getOutputStream(), terminal);
+            readline = holder.readline = new ConsoleReader("JRuby", runtime.getInputStream(), runtime.getOutputStream(), terminal);
         } catch (IOException ioe) {
             throw runtime.newIOErrorFromException(ioe);
         }


### PR DESCRIPTION
...hopefully

since the previous attempt (on runtime tear-down) does not always work, for reasons I do not comprehend
runtime tear-down is still in.

towards getting updates back: jruby/jruby#5387

its a hammer but this is also what tools such as highline do to work-around JRuby's readline 

would release this as **1.4.0**
