### PR TITLE
Can't use arrow keys on Windows jirb

### DIFF
--- a/src/main/java/org/jruby/ext/readline/Readline.java
+++ b/src/main/java/org/jruby/ext/readline/Readline.java
@@ -32,6 +32,8 @@ package org.jruby.ext.readline;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.IOException;
+import java.io.FileDescriptor;
+import java.io.FileInputStream;
 import java.nio.CharBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -119,7 +121,7 @@ public class Readline {
         final ConsoleReader readline;
         try {
             final Terminal terminal = TerminalFactory.create();
-            readline = holder.readline = new ConsoleReader(null, runtime.getInputStream(), runtime.getOutputStream(), terminal);
+            readline = holder.readline = new ConsoleReader(null, new FileInputStream(FileDescriptor.in), System.out, terminal);
         } catch (IOException ioe) {
             throw runtime.newIOErrorFromException(ioe);
         }


### PR DESCRIPTION
# Issue
I can't use arrow keys on Windows jirb.

# Versions which this issue occurs
- From JRuby 1.7.5
When I type arrow keys, `潯`, `潼`, `澑` and `潭` are inputed.

- From JRuby 9.1.3.0
When I type arrow keys, a cursor doesn't move.

# Causes
I found the following two causes.

First cause is JLine bug which was fixed in JLine 2.12. So we need to update JLine version.
(Currently JLine is updated in master branch of `jruby/jruby`, but it has not been released.)

Second cause is an argument of ConsoleReader constructor.
Related commit is 36c431516750570f8476bab1f68421d584693592.
I can't understand why I can't use arrow keys.
But, it looks good when I changed InputStream to FileInputStream which is default of ConsoleReader constructor.